### PR TITLE
Part 2 of #1255 - enabling visualeditor extension

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -25,6 +25,7 @@ attackontitan: true
 augustinianum: true
 aurcusonline: true
 ayrshire: true
+bch: true
 betapurple: true
 bettermedia: true
 betternews: true


### PR DESCRIPTION
Part 2 of #1255 - enabling visualeditor extension for bchwiki