### PR TITLE
Enable Parsoid on "PruebaWiki"

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -209,6 +209,7 @@ porp: true
 pq: true
 prfmuk: true
 priyo: true
+prueba: 'es.publictestwiki.com'
 pso2: true
 purpanrangueilus: true
 qwerty: true


### PR DESCRIPTION
Addition of Parsoid on Spanish PublicTestWiki for use VisualEditor Extension. Thanks.