### PR TITLE
Addition of "kevinincwiki" and "mikrodevdocswiki" for T1878 and T1879

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -135,6 +135,7 @@ justinbieber: true
 karmazynxyz: true
 karniaruthenia: true
 kassai: true
+kevininc: true
 kinderacic: true
 knowledge: true
 korach: true
@@ -164,6 +165,7 @@ menufeed: true
 meregos: true
 meta: true
 mikrodev: true
+mikrodevdocs: true
 miningpromies: true
 modular: true
 mozi: true


### PR DESCRIPTION
Addition of "kevinincwiki" and "mikrodevdocswiki" in Parsoid for Enable VisualEditor (See Phabricator Tasks [T1878](https://phabricator.miraheze.org/T1878) and [T1879](https://phabricator.miraheze.org/T1879)). Thanks.