### PR TITLE
Enabled NYCHousing wiki

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -197,6 +197,7 @@ nonbinary: true
 nvc: true
 nwp: true
 nxwiki: true
+nychousingwiki: true
 ofthevampire: true
 oncproject: true
 oolawiki: true


### PR DESCRIPTION
Enabled parsoid for NYWHousing wiki per request T2019.