### PR TITLE
Added n2go to parsoid

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -180,6 +180,7 @@ musiclibrary: true
 mydegree: true
 mylogic: true
 mynydd: true
+n2go: true
 nanatsunotaizai: true
 nationsglory: true
 nationstates: true


### PR DESCRIPTION
In conjunction with enabling VisualEditor on n2go.miraheze.org per request T2029