### PR TITLE
Enabling parsoid for feuwiki in conjunction with VE request

### DIFF
--- a/parsoid.yaml
+++ b/parsoid.yaml
@@ -97,6 +97,7 @@ extload: true
 fablabesds: true
 fantasia: true
 fbwiki: true
+feu: true
 fishpercolator: true
 fmbv: true
 foodsharinghamburg: true


### PR DESCRIPTION
Enabling parsoid for feu.miraheze.org per request T2094.